### PR TITLE
Fix to handing of 'ans' output

### DIFF
--- a/Source/Modules/matlab.cxx
+++ b/Source/Modules/matlab.cxx
@@ -751,7 +751,7 @@ int MATLAB::functionWrapper(Node *n){
     Printf(f->code, "%s\n", tm);
 
 
-    Printf(f->code, "if(--resc>=0) *resv++ = _out;\n");
+    Printf(f->code, "if(_out && --resc>=0) *resv++ = _out;\n");
     Delete(tm);
   } else {
     Swig_warning(WARN_TYPEMAP_OUT_UNDEF, input_file, line_number, "Unable to use return type %s in function %s.\n", SwigType_str(d, 0), iname);


### PR DESCRIPTION
I've taken a shot at fixing the lack of 'ans' output. From the testing I did, the wrapper now behaves the way I would expect MATLAB to behave.

You might want to run the test suite after this commit, since I wasn't able to do it myself.
